### PR TITLE
Update Python runtime to 3.9

### DIFF
--- a/templates/aws-fargate/cicd/aws/templates/2-ecs.yml
+++ b/templates/aws-fargate/cicd/aws/templates/2-ecs.yml
@@ -133,7 +133,7 @@ Resources:
       FunctionName: !Ref LambdaDeleteECRRepoFunctionName
       Handler: index.lambda_handler
       Role: !GetAtt DeleteECRRepoLambdaRole.Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: 60
       Code:
         ZipFile: !Sub |

--- a/templates/aws-fargate/cicd/aws/templates/3-pipeline.yml
+++ b/templates/aws-fargate/cicd/aws/templates/3-pipeline.yml
@@ -93,7 +93,7 @@ Resources:
       FunctionName: !Ref LambdaCleanupOnDeleteFunctionName
       Handler: index.lambda_handler
       Role: !GetAtt CleanupBucketOnDeleteLambdaRole.Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: 60
       Code:
         ZipFile: !Sub |


### PR DESCRIPTION
Hey Seth, first off thanks for this useful utility. I'm working on deploying a small ColdBox app to Fargate and your preso from Into The Box 2020 has been super helpful with the learning curve.

When I ran your deploy.sh I got some errors about Python 2.7 runtimes no longer being supported. So I updated these references to 3.9 and managed to complete the deploy successfully.

I also ran into a number of errors because my project name was long enough that a lot of the RoleName values exceeded 64 characters and would not validate with AWS. I'm not sure if this is something that should be addressed in the deploy script. I ended up manually changing a lot of the property names to be shorter to get it working.

Is this project still active & relevant? Or is there a more up to date way to do this type of thing?

Thanks again.